### PR TITLE
Found buggy API function

### DIFF
--- a/src/Vessel.cs
+++ b/src/Vessel.cs
@@ -240,6 +240,8 @@ public class Vessel /*: MonoBehaviour, ITargetable, IShipconstruct, IDiscoverabl
     public extern Vector3 findLocalCenterOfMass();
     public extern Vector3 findLocalCenterOfPressure();
     public extern Vector3 findLocalMOI();
+    /// <summary>Returns the vessel's moment of inertia around its center of mass.</summary>
+    /// <warning>Returns nonsense answers; DO NOT USE</warning>
     public extern Vector3 findLocalMOI(Vector3 worldCoM);
     /// <summary>
     /// Computes and returns the position of the center of mass of the vessel, in world coordinates.


### PR DESCRIPTION
The `Vessel.findLocalMOI()` function does not work as ~~advertised~~ inferred, and gave us a lot of grief over at RemoteTech. I've added a warning to the documentation.
