### PR TITLE
Updated CelestialBody.GetOrbit()

### DIFF
--- a/src/CelestialBody.cs
+++ b/src/CelestialBody.cs
@@ -184,7 +184,7 @@ public class CelestialBody /*: MonoBehaviour, ITargetable, IDiscoverable*/
     public extern double GetLongitude(Vector3d worldPos);
     public extern string GetName();
     public extern Vector3 GetObtVelocity();
-    /// <summary>Deprecated function that throws a NullReferenceException when called. Use GetOrbitDriver() instead.</summary>
+    /// <summary>Obsolete function that throws a NullReferenceException when called. Use GetOrbitDriver() instead.</summary>
     public extern Orbit GetOrbit();
     public extern OrbitDriver GetOrbitDriver();
     public extern Vector3d getPositionAtUT(double UT);


### PR DESCRIPTION
I found out the hard way that the orbit property no longer exists, and CelestialBody.GetOrbit() is broken as of 0.24.2. GetOrbitDriver() is still usable, though.
